### PR TITLE
"make login"時のエラー対応

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,6 @@
+include project.env
+SHELL=/bin/bash
+
 login: configure sso-login mfa finally
 	@aws-export-credentials --credentials-file-profile amplify
 


### PR DESCRIPTION
Fixes #4

```makefile
include project.env
SHELL=/bin/bash
```

envファイルにログイン時に必要な環境変数が記載されているので、include